### PR TITLE
PythonFormat should be YapfFormat in the README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,9 +56,9 @@ the current line in insert mode and the current range in visual mode:
 
 .. code:: vim
 
-  map <C-o> :%PythonFormat<CR>
-  imap <C-o> <ESC>:PythonFormat<CR>i
-  vmap <C-o> :PythonFormat<CR>
+  map <C-o> :%YapfFormat<CR>
+  imap <C-o> <ESC>:YapfFormat<CR>i
+  vmap <C-o> :YapfFormat<CR>
 
 Of course, the ``<C-o>`` can be changed to any key you like ;)
 


### PR DESCRIPTION
When describing the maps as example is giving a configuration that uses
PythonFormat instead of YapfFormat. This fixes that.
